### PR TITLE
Generic over choice of curve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 crate-type = ["lib"]
 
 [dependencies]
-curv = { git = "https://github.com/KZen-networks/curv", tag = "v0.3.4"}
+curv = { git = "https://github.com/survived/curv.git", branch = "expose-testing-macro"}
 bulletproof = {git = "https://github.com/KZen-networks/bulletproofs", tag = "v1.1.2"}
 serde_derive = "1.0"
 serde = "1.0"
@@ -18,6 +18,14 @@ rayon = "1.0.3"
 
 [dev-dependencies]
 criterion = "0.2"
+
+[dev-dependencies.curv]
+git = "https://github.com/survived/curv.git"
+branch = "expose-testing-macro"
+features = ["testing-utils"]
+
+[patch."https://github.com/survived/curv.git"]
+curv = { path = "../curv" }
 
 [[bench]]
 name = "v_backup"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ crate-type = ["lib"]
 
 [dependencies]
 curv = { git = "https://github.com/survived/curv.git", branch = "expose-testing-macro"}
-bulletproof = {git = "https://github.com/KZen-networks/bulletproofs", tag = "v1.1.2"}
+bulletproof = {git = "https://github.com/survived/bulletproofs", branch = "generic-curv"}
 serde_derive = "1.0"
 serde = "1.0"
 rayon = "1.0.3"
+zeroize = "0.10"
 
 [dev-dependencies]
 criterion = "0.2"
@@ -23,9 +24,6 @@ criterion = "0.2"
 git = "https://github.com/survived/curv.git"
 branch = "expose-testing-macro"
 features = ["testing-utils"]
-
-[patch."https://github.com/survived/curv.git"]
-curv = { path = "../curv" }
 
 [[bench]]
 name = "v_backup"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,13 @@ version 3 of the License, or (at your option) any later version.
 @license GPL-3.0+ <https://github.com/KZen-networks/centipede/blob/master/LICENSE>
 */
 
-// pub mod grad_release;
-// pub mod juggling;
+pub mod grad_release;
+pub mod juggling;
 pub mod wallet;
 extern crate bulletproof;
 extern crate curv;
 extern crate rayon;
+extern crate zeroize;
 
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ version 3 of the License, or (at your option) any later version.
 @license GPL-3.0+ <https://github.com/KZen-networks/centipede/blob/master/LICENSE>
 */
 
-pub mod grad_release;
-pub mod juggling;
+// pub mod grad_release;
+// pub mod juggling;
 pub mod wallet;
 extern crate bulletproof;
 extern crate curv;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -15,56 +15,60 @@ version 3 of the License, or (at your option) any later version.
 @license GPL-3.0+ <https://github.com/KZen-networks/centipede/blob/master/LICENSE>
 */
 
-use curv::arithmetic::traits::{Converter, Modulo};
+use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
 use curv::cryptographic_primitives::hashing::traits::*;
-use curv::elliptic::curves::secp256_k1::FE;
-use curv::elliptic::curves::secp256_k1::GE;
 use curv::elliptic::curves::traits::*;
 use curv::BigInt;
-pub struct SecretShare {
-    pub secret: FE,
-    pub pubkey: GE,
+
+pub struct SecretShare<P: ECPoint> {
+    pub secret: P::Scalar,
+    pub pubkey: P,
 }
 
-impl SecretShare {
-    pub fn generate() -> SecretShare {
-        let base_point: GE = ECPoint::generator();
-        let secret: FE = ECScalar::new_random();
+impl<P> SecretShare<P>
+where
+    P: ECPoint,
+    P::Scalar: Clone,
+{
+    pub fn generate() -> SecretShare<P> {
+        let base_point: P = ECPoint::generator();
+        let secret: P::Scalar = ECScalar::new_random();
 
-        let pubkey = base_point * &secret;
+        let pubkey = base_point * secret.clone();
         return SecretShare { secret, pubkey };
     }
     //based on VRF construction from ellitpic curve: https://eprint.iacr.org/2017/099.pdf
     //TODO: consider to output in str format
     pub fn generate_randomness(&self, label: &BigInt) -> BigInt {
-        let h = generate_random_point(&Converter::to_vec(label));
-        let gamma = h * &self.secret;
-        let beta = HSha256::create_hash_from_ge(&[&gamma]);
+        let h: P = derive_point(&Converter::to_vec(label));
+        let gamma = h * self.secret.clone();
+        let beta = HSha256::create_hash_from_ge::<P>(&[&gamma]);
         beta.to_big_int()
     }
 }
 
-pub fn generate_random_point(bytes: &[u8]) -> GE {
-    let result: Result<GE, _> = ECPoint::from_bytes(&bytes);
-    if result.is_ok() {
-        return result.unwrap();
-    } else {
-        let two = BigInt::from(2);
-        let bn = BigInt::from(bytes);
-        let bn_times_two = BigInt::mod_mul(&bn, &two, &FE::q());
-        let bytes = BigInt::to_vec(&bn_times_two);
-        return generate_random_point(&bytes);
-    }
+// TODO: Copy-paste from https://github.com/survived/bulletproofs/blob/1e856b17aefd37e2085144097df69c26832bb2b6/src/proofs/utils.rs#L6
+pub fn derive_point<P: ECPoint>(source: &[u8]) -> P {
+    let bn = BigInt::from(source);
+    let scalar = <P::Scalar as ECScalar>::from(&bn);
+    P::generator() * scalar
 }
 
 #[cfg(test)]
 mod tests {
-    use curv::BigInt;
-    use wallet::SecretShare;
-    #[test]
-    fn test_randomness() {
-        let x = SecretShare::generate();
+    use curv::elliptic::curves::traits::*;
+    use curv::{test_for_all_curves, BigInt};
+
+    use super::SecretShare;
+
+    test_for_all_curves!(test_randomness);
+    fn test_randomness<P>()
+    where
+        P: ECPoint,
+        P::Scalar: Clone,
+    {
+        let x = SecretShare::<P>::generate();
         let bitcoin_label = String::from("Bitcoin1").into_bytes();
         let ethereum_label = String::from("Ethereum1").into_bytes();
         let label_btc = BigInt::from(&bitcoin_label[..]);


### PR DESCRIPTION
PR makes algorithms described in the crate generic over choice of curve.

Blocked on:
- [ ] PR in `curv`: https://github.com/ZenGo-X/curv/pull/96
- [ ] PR in `bulletproof`: https://github.com/ZenGo-X/bulletproofs/pull/30
- [ ] P256 curve fails on those tests: 
  1. [ ] [test_secret_exchange](https://github.com/survived/centipede/blob/2cb7a53071f6ecfadf5e13460d21fad735c948d4/src/grad_release/mod.rs#L159)
  2. [ ] [test_verifiable_encryption](https://github.com/survived/centipede/blob/2cb7a53071f6ecfadf5e13460d21fad735c948d4/src/juggling/proof_system.rs#L323)